### PR TITLE
Export IOURef

### DIFF
--- a/Data/Mutable.hs
+++ b/Data/Mutable.hs
@@ -8,6 +8,7 @@ module Data.Mutable
       PRef
     , asPRef
     , URef
+    , IOURef
     , asURef
     , SRef
     , asSRef


### PR DESCRIPTION
The only exposed-module of mutable-containers is Data.Mutable, but Data.Mutable.URef defines and exports IOURef. As it is not used internally I assume it was intended to be exported to end-users for convenience.