### PR TITLE
Export IOPRef, IOSRef, IOBRef

### DIFF
--- a/Data/Mutable.hs
+++ b/Data/Mutable.hs
@@ -6,13 +6,16 @@ module Data.Mutable
     ( -- * Data types
       -- ** Single-cell mutable references
       PRef
+    , IOPRef
     , asPRef
     , URef
     , IOURef
     , asURef
     , SRef
+    , IOSRef
     , asSRef
     , BRef
+    , IOBRef
     , asBRef
       -- *** Standard re-exports
     , IORef


### PR DESCRIPTION
Whoops, I've just noticed the same aliases as #4 exist for other ref types. This should have been in previous PR, sorry.
